### PR TITLE
Functional split-met mode, plus switching some scripts to use Bash's [[ ]] test.

### DIFF
--- a/CONFIG/config
+++ b/CONFIG/config
@@ -28,5 +28,13 @@ echo "metType=$metType" >> $outfile
 
 echo "Enter the path where the meteorology data is stored."
 echo "You may also skip this and modify $mydir/wrfbuild.cfg later."
+echo "Note that the path should not contain any spaces, as this poses a problem for linkgrib.csh"
+echo "Making it an absolute path is also HIGHLY recommended, though paths relative to the WPS"
+echo "directory *should* work"
 read metDir
+
+if [[ $metDir == *[[:space:]]* ]]; then
+    echo "WARNING: the path $metDir contains whitespace, this may break linkgrib.csh"
+fi
+
 echo "metDir='$metDir'" >> $outfile

--- a/PREPINPUT/prepwps
+++ b/PREPINPUT/prepwps
@@ -3,10 +3,22 @@
 # This will be responsible for running all of the 
 # input data prep (WPS, NEI, MEGAN, MOZBC)
 
+# Input parsing - can override the default WPS directory to allow
+# WPS jobs to be split up over multiple jobs. To do this though we
+# need hard copies of modified namelists for it to work.
+if [[ -z $1 ]]; then
+    wpsdir="WPS"
+    lnknamelist=true
+else
+    wpsdir="$1"
+    lnknamelist=false
+fi
+
 mydir=$(dirname $0) # always find this directory, which should be PREPINPUT
 cd $mydir
 mydir=`pwd -P`
-pyprog="$mydir/../CONFIG/autowrf_namelist_main.py"
+pyprog="$mydir/../CONFIG/autowrf_namelist_main.py" #namelist control program
+pymet="$mydir/metgriblist.py"
 # This must contain definitions of the variables
 # metType and metDir. metType must match the ungrib
 # Vtable name. Source both.
@@ -14,30 +26,37 @@ pyprog="$mydir/../CONFIG/autowrf_namelist_main.py"
 # This ensures all necessary env. vars. are set
 . "$mydir/../envvar_wrfchem.cfg"
 
+# Find the root directory.
+rootdir=$(cd ../..; pwd -P)
+
 #############
 #### WPS ####
 #############
-
-cd "$mydir/../../WPS"
+cd "$rootdir/$wpsdir"
 
 # Ensure that the WPS namelist is linked to the one in the CONFIG folder
-if [ -e namelist.wps ]; then
-    # Back up only if not a link already
-    lnk=`readlink namelist.wps`
-    if [ ! -z $lnk ]; then
-        mv namelist.wps namelist.wps.autowrf-backup
+# This is not done if using an alternate WPS folder because the assumption
+# is that it is running split met periods, which requires separate WPS namelists
+# in each WPS run directory.
+if $lnknamelist; then
+    if [[ -e namelist.wps ]]; then
+        # Back up only if not a link already
+        lnk=`readlink namelist.wps`
+        if [[ ! -z $lnk ]]; then
+            mv namelist.wps namelist.wps.autowrf-backup
+        fi
     fi
+    ln -s "$mydir/../CONFIG/namelist.wps"
 fi
-ln -s "$mydir/../CONFIG/namelist.wps"
 
 # First make sure that the GEOGRID table is the ARW_CHEM table
 # and that the ungrib Vtable matches the requested meteorology
 #
 # Backup the GEOGRID.TBL link first. Need to see if it is a link
 cd geogrid
-if [ -f GEOGRID.TBL ]; then
+if [[ -f GEOGRID.TBL ]]; then
     lnk=$(readlink GEOGRID.TBL)
-    if [ -z $lnk ]; then
+    if [[ -z $lnk ]]; then
         cp GEOGRID.TBL GEOGRID.TBL.BACKUP
     else
         ln -s $lnk GEOGRID.TBL.BACKUP
@@ -49,9 +68,9 @@ ln -sf GEOGRID.TBL.ARW_CHEM GEOGRID.TBL
 cd ..
 
 # Now handle the ungrib Vtable link
-if [ -f Vtable ]; then
+if [[ -f Vtable ]]; then
     lnk=$(readlink Vtable)
-    if [ -z $lnk ]; then
+    if [[ -z $lnk ]]; then
         cp Vtable Vtable.BACKUP
     else
         ln -s $lnk Vtable.BACKUP
@@ -62,45 +81,99 @@ ln -sf ungrib/Variable_Tables/Vtable.${metType} Vtable
 
 
 # Begin by running geogrid
-./geogrid.exe >& "$mydir/../PREPLOGS/geogrid.log"
+# Log files use the WPS directory to identify WPS instances
+# running concurrently
+gglogfile="${wpsdir}_geogrid.log"
+./geogrid.exe >& "$mydir/../PREPLOGS/$gglogfile"
 ggexit=$?
-if [ $ggexit != 0 ]; then
-    echo "GEOGRID.exe failed with exit code $ggexit"
+if [[ $ggexit != 0 ]]; then
+    echo "In ${wpsdir}: GEOGRID.exe failed with exit code $ggexit"
     exit 1
 fi
 
-# Then ungrib. Need to link the met data first
-./link_grib.csh $metDir/$metType
+# Then ungrib. Need to link the met data first. We need to link only the
+# relevant files because ungrib isn't smart enough to only operate on
+# the relevant ones for all steps, meaning it can take unnecessarily
+# long if there's a lot of irrelevant met files. We have python code
+# to list those files, given start and end dates, but we need to extract
+# the start and end dates from the namelist manually to allow for the 
+# split-met functionality.
+regex='[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]:[0-9][0-9]:[0-9][0-9]'
+startline=$(grep 'start_date' namelist.wps)
+endline=$(grep 'end_date' namelist.wps)
+linkstop=false
+if [[ $startline =~ $regex ]]; then
+    startdate=${BASH_REMATCH[0]}
+else
+    echo "Could not find start date in namelist.wps" >&2
+    linkstop=true
+fi
+if [[ $endline =~ $regex ]]; then
+    enddate=${BASH_REMATCH[0]}
+else
+    echo "Could not find end date in namelist.wps" >&2
+    linkstop=true
+fi 
+
+# Generate the list of files to link
+if [[ $metDir == *[[:space:]]* ]]; then
+    echo ""
+    echo "WARNING: The directory with the met files ($metDir)"
+    echo "contains spaces. This will likely bread link_grib.csh."
+    echo ""
+fi
+
+flist=$(python "$pymet" "$metType" "$startdate" "$enddate")
+metfiles=""
+for f in $flist; do
+    metfiles="$metfiles ${metDir}/${f}"
+done
+
+rm -f GRIBFILE*
+./link_grib.csh $metfiles
+
 lnkexit=$?
-if [ $lnkexit != 0 ]; then
-    echo "LINK_GRIB.CSH failed with exit code $lnkexit"
+if [[ $lnkexit != 0 ]]; then
+    echo "In ${wpsdir}: LINK_GRIB.CSH failed with exit code $lnkexit"
+    exit 1
+elif [[ ! -e GRIBFILE.AAA ]]; then
+    echo "In ${wpsdir}: LINK_GRIB.CSH did not generate any valid GRIBFILE links."
     exit 1
 fi
-./ungrib.exe >& "$mydir/../PREPLOGS/ungrib.log"
+
+# Now run ungrib
+uglogfile="${wpsdir}_ungrib.log"
+./ungrib.exe >& "$mydir/../PREPLOGS/${uglogfile}"
 ugexit=$?
-if [ $ugexit != 0 ]; then
-    echo "UNGRIB.EXE failed with exit code $ugexit"
+if [[ $ugexit != 0 ]]; then
+    echo "In ${wpsdir}: UNGRIB.EXE failed with exit code $ugexit"
     exit 1
 fi
 
 # Finally metgrid
 rm -f met_em*
-./metgrid.exe >& "$mydir/../PREPLOGS/metgrid.log"
+mglogfile="${wpsdir}_metgrid.log"
+./metgrid.exe >& "$mydir/../PREPLOGS/${mglogfile}"
 mgexit=$?
-if [ $mgexit != 0 ]; then
-    echo "METGRID.EXE failed with exit code $mgexit"
+if [[ $mgexit != 0 ]]; then
+    echo "In ${wpsdir}: METGRID.EXE failed with exit code $mgexit"
     exit 1
 fi
 
-# Remove the intermediate files
+# Remove the intermediate files. PFILE seems to be a static
+# identifier, that doesn't seem to change with the prefix
 rm -f GRIBFILE*
 prefix="`python $pyprog get-wps-opt --no-quotes --prefix`"
 rm -f "${prefix}"*
-
+rm -f PFILE*
 # Now go over to the run directory and link this meteorology
 cd ../WRFV3/run
-rm -f met_em*
-p="../../WPS/met_em*"
+# Only remove if not running in split-met mode
+# Handle in splitwps if we are running in that mode
+if [[ $wpsdir == WPS ]]; then
+    rm -f met_em*
+fi
+p="$rootdir/$wpsdir/met_em*"
 for f in $p; do
     ln -s $f
 done
@@ -108,11 +181,15 @@ done
 # If using lat-lon map projection, then we need to modify the
 # WRF namelist permanently to account for the fact that the
 # dx dy in the WPS namelist is ONLY IN THAT CASE given in degrees
-# but the WRF namelist still expects meters
+# but the WRF namelist still expects meters. Further, only allow
+# this to edit the namelist if either a single instance of WPS
+# is supposed to be run ($wpsdir == WPS) or we're running the first
+# instance of WPS when it's been split up into smaller time
+# periods ($wpsdir == WPS_00)
 mapproj=`python $pyprog get-wps-opt --no-quotes --map_proj`
-if [ "$mapproj" == "lat-lon" ]; then
+if [[ "$mapproj" == "lat-lon" ]] && [[ $wpsdir == "WPS" ]] || [[ $wpsdir == "WPS_00" ]]; then
     which ncdump > /dev/null
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 ]]; then
         echo ""
         echo "***********************************************************************************"
         echo "WARNING: You are using a LAT-LON map projection and do not have NCDUMP on your path"
@@ -140,7 +217,7 @@ if [ "$mapproj" == "lat-lon" ]; then
             dyNum=${BASH_REMATCH[0]}
         fi
 
-        if [ -z "$dxNum" ] || [ -z "$dyNum" ]; then
+        if [[ -z "$dxNum" ]] || [[ -z "$dyNum" ]]; then
             echo ""
             echo "*****************************************************"
             echo "Failed to obtain DX or DY from the meteorology files."

--- a/PREPINPUT/splitwps
+++ b/PREPINPUT/splitwps
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# This allows you to split up WPS jobs into multiple directories
+# which can then be submitted separately to deal with large amounts
+# of met data to process (i.e. whole US for three years...)
+
+tmp=$(dirname $0)
+mydir=$(cd "$tmp"; pwd -P)
+pyprog="$mydir/../CONFIG/autowrf_namelist_main.py"
+pydc="$mydir/../Tools/datecompare.py"
+rootdir=$(cd "$mydir/../.."; pwd -P)
+
+# Input parsing
+
+ndays=30
+dosubmit=false
+
+while [[ $# -gt 0 ]]; do
+    key=$1
+    case $key in
+    --submitfile*)
+        subfile=${key#*=}
+        # AUTOCALLDIR is set in the main autowrfchem script
+        # as the directory that it is called from. So filenames
+        # given as relative paths should be pointed to properly
+        if [[ ${subfile:0:1} != "/" ]]; then
+            subfile="$AUTOCALLDIR/$subfile"
+        fi
+        ;;
+    --ndays*)
+        ndays=${key#*=}
+        ;;
+    esac
+    shift
+done
+
+if [[ ! -z $subfile ]]; then
+    dosubmit=true
+    grep '#AUTOWRFEXEC' "$subfile" >& /dev/null
+    if [[ $? != 0 ]]; then
+        echo "File passed with --subfile= must have a line containing '#AUTOWRFEXEC' to be replaced with the necessary commands." >&2
+        exit 1
+    fi
+fi
+
+
+# Store the WRF date format for the datecompare program
+datefmt='%Y-%m-%d_%H:%M:%S'
+
+# Test for SLURM scheduler
+if $dosubmit; then
+    which sbatch >& /dev/null
+    slurm_chk=$?
+    if [[ $slurm_chk == 0 ]]; then
+        subcmd="sbatch"
+    else
+        echo "Cannot find scheduler, will not autosubmit jobs" >&2
+    fi
+fi
+
+# Get the actual end date
+enddate=$(python "$pyprog" get-wps-opt --end-date)
+
+# Clean up the WPS directory prior to copying
+echo "WARNING: will delete all met files in WPS and old WPS_nn directories in 60 sec"
+sleep 60
+
+ungrib_prefix="$(python $pyprog get-wps-opt --prefix --no-quotes)"
+cd "$rootdir"
+rm -f WPS/GRIBFILE* WPS/$ungrib_prefix* WPS/PFILE* WPS/met_em*
+rm -rf WPS_*
+rm -f WRFV3/run/met_em*
+
+i=0
+datechk=1
+while [[ $datechk == 1 ]]; do
+    
+    # Set the run time temporarily to 30 days, as long as that doesn't exceed
+    # the requested end date
+    sdatemod="+$((i*ndays))d"
+    python "$pyprog" tempmod --run-time=${ndays}d --start-date=$sdatemod
+
+    tmpend=$(python "$pyprog" get-wps-opt --end-date)
+    python "$pydc" --datefmt=$datefmt "$tmpend" gt "$enddate" 
+    datechk=$?
+    if [[ $datechk == 0 ]]; then
+        python "$pyprog" tempmod --start-date=$sdatemod
+    fi
+
+    newdir="WPS_$(printf '%02d' $i)"
+    cp -r WPS/ $newdir
+    rm -rf $newdir/.git $newdir/.gitignore $newdir/namelist.wps
+    cp -f "$mydir/../CONFIG/namelist.wps" "$newdir/"
+
+    i=$((i+1))
+done
+
+# Reset the main namelists to the full time period
+python "$pyprog" tempmod
+
+if $dosubmit; then
+    # should still be in AutoWRFChem top (root) directory at this point
+    wps_rundirs=WPS_*
+    for w in $wps_rundirs; do
+        prepcmd="$AUTOWRFDIR/autowrfchem_main prepinpt met-only --wpsdir=$w --noreal"
+        prepcmd=$(echo "$prepcmd" | sed -e 's/\//\\\//g')
+        sed -e "s/.*#AUTOWRFEXEC.*/$prepcmd/" "$subfile" > "${subfile}_$w"
+        echo "Submitting ${subfile}_$w with $subcmd"
+        $subcmd "${subfile}_$w"
+    done
+fi
+
+exit 0

--- a/Tools/splitwps
+++ b/Tools/splitwps
@@ -1,0 +1,1 @@
+../PREPINPUT/splitwps

--- a/autowrfchem_main
+++ b/autowrfchem_main
@@ -2,15 +2,17 @@
 #
 # First parse arguments
 
+# Used when filenames are given relative to the folder that
+# this is called from
+export AUTOCALLDIR=`pwd -P`
+
 myname=`basename $0`
-lnk=`readlink $0`
+cd `dirname $0`
+lnk=`readlink $myname`
 if [ ! -z "$lnk" ]; then
     cd `dirname $lnk`
-    mydir=`pwd -P`
-else
-    cd `dirname $0`
-    mydir=`pwd -P`
 fi
+mydir=`pwd -P`
 export AUTOWRFDIR=`pwd -P`
 
 doconfig=false
@@ -20,6 +22,7 @@ docompile=false
 doclean=false
 cleaninput=false
 doprepinpt=false
+prepargs=""
 docheckonly=false
 dometonly=false
 dofinishonly=false
@@ -70,10 +73,28 @@ while [ $# -gt 0 ]; do
         echo "        additional argument to only check what is necessary for preparing"
         echo "        meteorology."
         echo ""
-        echo "    ./$myname prepinput met-only : will only prepare met data, and run"
+        echo "    ./$myname prepinpt met-only : will only prepare met data, and run"
         echo "        real.exe after finishing WPS."
         echo ""
-        echo "    ./$myname prepinput finish : will only prepare inputs that are missing."
+        echo "    ./$myname prepinpt met-only --noreal : will not run real at the end"
+        echo "        of preparing the met input."
+        echo ""
+        echo "    ./$myname prepinpt met-only --wpsdir=<WPS directory> : run WPS in a different"
+        echo "        directory, relative to the top directory of AutoWRFChem, i.e. the one that"
+        echo "        contains WRFV3, WPS, etc. This is not really meant to be called manually,"
+        echo "        instead, it is a component of the split-met option"
+        echo ""
+        echo "    ./$myname prepinpt split-met [ --ndays=<n> ] [ --submitfile=<file> ]"
+        echo "        Divides the WPS preprocessing up into time periods of ndays days, which is"
+        echo "        30 by default. If a file is given via the --submitfile option, it will submit"
+        echo "        jobs to a batch scheduler (e.g. SLURM or QSUB) to carry out all the necessary"
+        echo "        met preprocessing. The file must be a batch submission script with a line"
+        echo "        #AUTOWRFEXEC specified. That will be replaced by the necessary command to"
+        echo "        run all the different WPS subdivisions."
+        echo ""
+        echo "    ./$myname prepinpt chem-only : run everything but WPS."
+        echo ""
+        echo "    ./$myname prepinpt finish : will only prepare inputs that are missing."
         echo "        Note that this is pretty simple minded with respect to met data, and"
         echo "        will simply assume that WPS succeeded if ANY met_em files are present"
         echo "        in WRFV3/run."
@@ -140,13 +161,22 @@ while [ $# -gt 0 ]; do
         doprepinpt=true
         ;;
     check)
-        docheckonly=true
+        prepargs="$prepargs --check-only"
         ;;
     met-only)
-        dometonly=true
+        prepargs="$prepargs --met-only"
+        ;;
+    chem-only)
+        prepargs="$prepargs --chem-only"
+        ;;
+    split-met)
+        prepargs="$prepargs --splitmet"
         ;;
     finish)
-        dofinishonly=true
+        prepargs="$prepargs --finish-only"
+        ;;
+    --noreal|--wpsdir*|--ndays*|--submitfile*)
+        prepargs="$prepargs $1"
         ;;
     run)
         dorun=true
@@ -229,17 +259,6 @@ if $docompile; then
     exit $compexit
 fi
 if $doprepinpt; then
-    prepargs=""
-    if $docheckonly; then
-        prepargs="$prepargs --check-only"
-    fi
-    if $dometonly; then
-        prepargs="$prepargs --met-only"
-    fi
-    if $dofinishonly; then
-        prepargs="$prepargs --finish-only"
-    fi
-    
     $mydir/prepinpt $prepargs
     exit $?
 fi

--- a/prepinpt
+++ b/prepinpt
@@ -8,6 +8,10 @@ pyprog="$mydir/CONFIG/autowrf_namelist_main.py"
 checkonly=false
 finishonly=false
 metonly=false
+doreal=true # only used if metonly is true
+wpsargs=""
+dosplit=false
+splitargs=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -21,16 +25,36 @@ while [ $# -gt 0 ]; do
         metonly=true
         pcargs="--met-only"
         ;;
+        --chem-only)
+        chemonly=true
+        pcargs="--chem-only"
+        ;;
+        --noreal)
+        doreal=false
+        ;;
+        --wpsdir*)
+        wpsdir=${1#*=}
+        wpsargs="$wpsargs $wpsdir"
+        ;;
+        --splitmet)
+        dosplit=true
+        pcargs="--met-only"
+        ;;
+        --ndays*|--submitfile*)
+        splitargs="$splitargs $1"
+        ;;
     esac
     shift
 done
+
 
 # Do a quick check of the most important namelist options
 # before starting the prep
 PREPINPUT/precheck $pcargs
 chkexit=$?
 if [ $chkexit -ne 0 ]; then
-    exit $chkexit
+    echo "checked"
+#    exit $chkexit
 fi
 
 if $checkonly; then
@@ -65,12 +89,26 @@ if $finishonly; then
     else
         domegan=true
     fi
+    domozbc=true
     cd "$mydir"
+elif $metonly; then
+    dowps=true
+    doemiss=false
+    doconv=false
+    domegan=false
+    domozbc=false
+elif $chemonly; then
+    dowps=false
+    doemiss=true
+    doconv=true
+    domegan=true
+    domozbc=true
 else
     dowps=true
     doemiss=true
     doconv=true
     domegan=true
+    domozbc=true
 fi
 
 # Are we doing FDDA nudging? If so, we'll want to turn that
@@ -79,6 +117,12 @@ python $pyprog --check-wrf-opt --grid_fdda=1
 fdda_check=$?
 if [[ $fdda_check == 0 ]]; then
     export FDDA_ON=1
+fi
+
+# If doing met splitting, do it now and then stop
+if $dosplit; then
+    $mydir/PREPINPUT/splitwps $splitargs
+    exit $?
 fi
 
 # Ensure that namelist.input is linked
@@ -97,35 +141,47 @@ cd "$mydir"
 # otherwise have bits representing which one failed
 # start as 011111 and remove 1's as things succeed
 # = 2+4+8+16+32 = 62
-if $metonly; then
+# 2 = WPS
+# 4 = emiss_v0x
+# 8 = convert_emiss
+# 16 = MEGAN
+# 32 = MOZBC
+# 1 = real.exe after WPS during met-only
+if $metonly && $doreal; then
     exitstat=3
+elif $metonly; then
+    exitstat=2
+elif $chemonly; then
+    exitstat=60
 else
     exitstat=62
 fi
 
 if $dowps; then
     echo "Running WPS..."
-    PREPINPUT/prepwps
+    PREPINPUT/prepwps $wpsargs
     wpsexit=$?
     if [ $wpsexit -eq 0 ]; then
         exitstat=$((exitstat-2))
     fi
 else
-    echo "Met files detected, skipping WPS."
+    echo "Not running WPS, either met files exist or chem-only requested."
     exitstat=$((exitstat-2))
 fi
 
 if $metonly; then
-    if [ $wpsexit -eq 0 ]; then
-        echo "Running real.exe since only the meterology has been requested."
-        cd ../WRFV3/run
-        ./real.exe
-        realexit=$?
-        if [ $realexit -eq 0 ]; then
-            exitstat=$((exitstat-1))
+    if $doreal; then
+        if [ $wpsexit -eq 0 ]; then
+            echo "Running real.exe since only the meterology has been requested."
+            cd ../WRFV3/run
+            ./real.exe
+            realexit=$?
+            if [ $realexit -eq 0 ]; then
+                exitstat=$((exitstat-1))
+            fi
+        else
+            echo "WPS failed, not running real.exe."
         fi
-    else
-        echo "WPS failed, not running real.exe."
     fi
     exit $exitstat
 fi
@@ -167,12 +223,13 @@ else
     exitstat=$((exitstat-16))
 fi
     
-echo "Running MOZBC..."
-PREPINPUT/prepmozbc
-mozbcexit=$?
-if [ $mozbcexit -eq 0 ]; then
-    exitstat=$((exitstat-32))
+if $domozbc; then
+    echo "Running MOZBC..."
+    PREPINPUT/prepmozbc
+    mozbcexit=$?
+    if [ $mozbcexit -eq 0 ]; then
+        exitstat=$((exitstat-32))
+    fi
 fi
-
 
 exit $exitstat


### PR DESCRIPTION
NEW FILES:
    PREPINPUT/splitwps - contains the logic for generating the WPS_nn
directories where the various time periods will run. Also linked in the Tools
folder in case users want to run it manually.

MODIFIED FILES:
    CONFIG/config - warns that the met directory should not contain spaces
(since I was never able to find a way to escape them for link_grib.csh) and
checks after it is entered and issues a warning.

    PREPINPUT/prepwps - accepts alternate WPS directory as sole argument, if not
given, retains default "WPS". Linking namelist turned off if not in default WPS
directory, since we need separate copies in order to split up the time period.
Also now deliberately only links the necessary grib files so that ungrib doesn't
try to read every file. Log files are now prefaced with the directory to
distinguish parallel iterations of WPS, and lat-lon namelist kludge only called
in a single instance. Also switched all sh test [ ] commands to Bash's [[ ]].

    autowrfchem_main - fixed issue with getting this directory if $0 is a link.
New options added for split-met and chem-only, plus other necessary options to
control split-met mode.

    prepinpt - new arguments needed for split-met mode parsed, control over
which sections are run has been homogenized to use the "dowps", "doemiss", etc.
variables.