### PR TITLE
Bugfix in prepinpt (chemonly bool not set). Added emissions opts to chemlist.txt

### DIFF
--- a/CONFIG/chemlist.txt
+++ b/CONFIG/chemlist.txt
@@ -11,6 +11,9 @@
 
 BEGIN RADM2
     wrf:chem:chem_opt = 2
+    wrf:chem:io_style_emissions = 1
+    wrf:chem:emiss_inpt_opt = 1
+    wrf:chem:emiss_opt = 3
     wrf:chem:chem_in_opt = 0
     wrf:chem:phot_opt = 2
     wrf:chem:gas_drydep_opt = 1
@@ -33,6 +36,9 @@ END RADM2
 BEGIN R2SMH
 @ISKPP
     wrf:chem:chem_opt = 113
+    wrf:chem:io_style_emissions = 1
+    wrf:chem:emiss_inpt_opt = 1
+    wrf:chem:emiss_opt = 11
     wrf:chem:chem_in_opt = 0
     wrf:chem:phot_opt = 2
     wrf:chem:gas_drydep_opt = 1

--- a/prepinpt
+++ b/prepinpt
@@ -9,6 +9,7 @@ checkonly=false
 finishonly=false
 metonly=false
 doreal=true # only used if metonly is true
+chemonly=false
 wpsargs=""
 dosplit=false
 splitargs=""


### PR DESCRIPTION
Fixes a bug in prepinpt that was causing WPS to be skipped unless doing split mode, this was because the chemonly flag was never set to false before arg parsing.

Also added separate feature: emissions options are now given in chemlist.txt. The R2SMH option assumes that the NEI and WRF modules have been updated with Azimeh's modified emissions mapping.