### PR TITLE
Added the --run-for option for running WRF, it allows you to specify a shortened run time than the namelist.

### DIFF
--- a/autowrfchem_main
+++ b/autowrfchem_main
@@ -111,6 +111,13 @@ while [ $# -gt 0 ]; do
         echo "    ./$myname run rst --allow-no-file : if no restart files in the proper"
         echo "        time period found, this will start from the beginning instead of"
         echo "        aborting."
+        echo "    ./$myname run --run-for=x : only run for x, where x is a time period in days,"
+        echo "        hours, minutes, and seconds. Works with rst, in fact, is primarily intended"
+        echo "        to work with rst so that you can break a long run up into smaller chunks."
+        echo "        This uses the tempmod function of the python namelist editor, so it retains"
+        echo "        knowledge of what your intended overall end time is and will not go past it."
+        echo "        Example: ./$myname run rst --run-for=28d will run for 28 days from the last"
+        echo "        restart file."
         echo ""
         echo ""
         echo "  Exit codes for the compile and prepinpt steps will indicate which step"
@@ -192,6 +199,9 @@ while [ $# -gt 0 ]; do
         ;;
     --allow-no-file)
         runargs="$runargs --allow-no-file"
+        ;;
+    --run-for*)
+        runargs="$runargs $1"
         ;;
     *)
         echo "$1 is not a recognized option"

--- a/runwrf
+++ b/runwrf
@@ -11,6 +11,7 @@ cd `dirname $0`
 myname=`basename $0`
 mydir=`pwd -P`
 pyprog="$mydir/CONFIG/autowrf_namelist_main.py"
+pydate="$mydir/Tools/datecompare.py"
 
 # See if this was called with the "override" flag
 override=false
@@ -39,6 +40,10 @@ while [ $# -gt 0 ]; do
         --allow-no-file)
             errnorst=false
             ;;
+        --run-for*)
+            i=`expr index $1 "="`
+            runfor=${1:i}
+            ;;
     esac
     shift
 done
@@ -51,6 +56,9 @@ if $usempi; then
         exit 1
     fi
 fi
+
+# Undo any other temporary changes to the namelist
+python "$pyprog" tempmod
 
 cd ../WRFV3/run
 if [ ! "namelist.input" -ef "$mydir/CONFIG/namelist.input" ]; then
@@ -108,6 +116,17 @@ if $missingfile; then
     exit 1
 fi
 
+# If the --run-for flag is given, we'll need to set the run time to match. Do not exceed the
+# given end date, so we'll need to test that after figuring out the start time (from the
+# restart file if specified). Now we can go ahead and check vs. the specified start time
+nl_startdate=$(python "$pyprog" get-wps-opt --no-quotes --start_date)
+nl_enddate=$(python "$pyprog" get-wps-opt --no-quotes --end_date)
+if [[ ! -z $runfor ]]; then
+    python "$pydate" --datefmt='%Y-%m-%d_%H:%M:%S' "$nl_startdate" "+$runfor" lt "$nl_enddate"
+    if [[ $? == 0 ]]; then
+        runtimearg="--run-time=$runfor"
+    fi
+fi
 
 # If we need to restart, then find the last restart file and set the date to it
 if $rst; then
@@ -116,7 +135,13 @@ if $rst; then
         regex="[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]:[0-9][0-9]:[0-9][0-9]"
         if [[ $rstfile =~ $regex ]]; then
             rdate="${BASH_REMATCH[0]}"
-            python $pyprog tempmod --start-date="$rdate" --restart=".true."
+            python "$pydate" --datefmt='%Y-%m-%d_%H:%M:%S' "$rdate" "+$runfor" "ge" "$nl_enddate"
+            if [[ $? == 0 ]]; then
+                # If the specified run time would cause the new end time to be after the one
+                # given in the namelist, then do not modify the run time
+                runtimearg=""
+            fi
+            python $pyprog tempmod --start-date="$rdate" --restart=".true." $runtimearg
         else
             echo "$myname: Could not determine date of restart file ($rstfile)"
             exit 1
@@ -127,9 +152,11 @@ if $rst; then
             exit 1
         else
             echo "No restart file in the time period of the namelist found, starting at beginning"
-            python $pyprog tempmod --restart=".false."
+            python $pyprog tempmod --restart=".false." $runtimearg
         fi
     fi
+elif [[ ! -z $runfor ]]; then
+    python $pyprog tempmod $runtimearg
 fi
 
 # Actually run WRF!


### PR DESCRIPTION
The goal is to be able to specify how long each job should simulate (which will
be useful for long runs) while still retaining knowledge of how long the total
simulation is for.

MODIFIED FILES:
    Tools/datecompare.py - refactored to allow you to add or subtract
time to either date before the comparison.

    autowrfchem_main - passes the --run-for option to runwrf.

    runwrf - if given the --run-for option, it checks if setting that
run time would make the run shorter than specified in the namelist,
starting from a restart file if desired. If so, then the run time is
changed to that specified in the --run-for option. This is intended
mainly for long runs that need to be broken up into separate jobs,
so you can run for e.g. 30 days from the last restart file, restarting
further each time, until the end time in the namelist is reached. Note
that presently there is no mechanism to halt submission if the end was
already reached.