### PR TITLE
Mainly a bugfix resulting from FDDA and split-wps interaction

### DIFF
--- a/CONFIG/autowrf_namelist_main.py
+++ b/CONFIG/autowrf_namelist_main.py
@@ -257,6 +257,7 @@ if __name__ == "__main__":
             pass
         SaveMenu(nlc)
     if len(arg) > 1:
+        WRF.DEBUG_LEVEL=0 #turn off normal messages from the classlib interface to prevent sending erroneous strings into the shell
         if arg[1] == "-h" or arg[1] == "--help":
             PrintHelp("DOC")
             print("Allowed met types are: ", end="")

--- a/PREPINPUT/metgriblist.py
+++ b/PREPINPUT/metgriblist.py
@@ -26,9 +26,11 @@ def narr_end_of_range_date(curr_date, ndays):
         # month range returns two values; the second is the number of days
         # in the given month
         eor_date = dt.date(curr_date.year, curr_date.month, eom_day)
-    elif eom_day - eor_date.day <= 1:
+    elif eom_day - eor_date.day <= 1 and eor_date.month != 2:
         # At the the 3D NARR files have an extra day if it would otherwise be the
-        # day before the end of the month
+        # day before the end of the month, except in February. (The algorithm NARR
+        # seems to use to generate filenames/ranges is very obtuse. It seems like
+        # they must've hand-specified ranges.)
         eor_date = eor_date.replace(day=eom_day)
 
     return eor_date
@@ -73,6 +75,12 @@ def list_narr_files(narr_files, start_date, end_date, stem, ndays, extension="ta
     # Day of month must be a multiple of ndays plus 1
     while dom % ndays != 1:
         dom -= 1
+
+    if stem == "NARR3D_" and dom == 31:
+        # This kludge fixes a bug that occurs if the time period requested
+        # starts on the 31st - 31 to 31 fits the rules that work for everything
+        # else, but NARR3D files are produced for 28 to 31, not 28 to 30 and 31 to 31.
+        dom = 28
 
     curr_date = dt.date(start_date.year, start_date.month, dom)
     while curr_date <= end_date:

--- a/PREPINPUT/postcheck.py
+++ b/PREPINPUT/postcheck.py
@@ -39,6 +39,7 @@ def get_var_names(filename):
     else:
         rgrp = ncdat(filename)
         return rgrp.variables.keys()
+        rgrp.close()
 
 def get_var_values(varnames, filename):
     if use_ncdump:
@@ -48,6 +49,7 @@ def get_var_values(varnames, filename):
         rgrp = ncdat(filename)
         for var in varnames:
             var_vals[var] = rgrp.variables[var][:]
+        rgrp.close()
     return var_vals
             
 

--- a/PREPINPUT/prepnei_convert
+++ b/PREPINPUT/prepnei_convert
@@ -65,6 +65,8 @@ if [ ! -f wrfchemi_00z_d01 ]; then
     exit 1
 fi
 
+cp -f rsl.error.0000 $mydir/../PREPLOGS/convert_00z.log
+
 # Now set up for the second 12 hr segment
 python $pyprog tempmod --start-date=12:00:00 --run-time=11h --bio_emiss_opt=0 $fdda_args
 
@@ -90,6 +92,8 @@ if [ ! -f wrfchemi_12z_d01 ]; then
     echo "mpirun if compiled in parallel) and check any output to identify the problem."
     exit 1
 fi
+
+cp -f rsl.error.0000 $mydir/../PREPLOGS/convert_12z.log
 
 # Restore the namelist to its user defined state, minus grid_fdda if it was on
 python $pyprog tempmod $fdda_args


### PR DESCRIPTION
MODIFIED FILES:
    CONFIG/autowrf_classlib.py - print calls outside the UI functions
replaced with msg_print(), which can be turned off by setting the module
variable DEBUG_LEVEL to 0. This prevents printing messages that get taken
by the shell when saving output to a variable with the $() notation.

    CONFIG/autowrf_namelist_main.py - for any shell commands, sets DEBUG_LEVEL
for the classlib to 0.

    PREPINPUT/postcheck.py - close netCDF files when done with them.

    PREPINPUT/metgriblist.py - added necessary kludge to handle run time
starting on the 31st of a month, which erroneously generated NARR3d_yyyymm_3131
as an expected file.

    PREPINPUT/prepnei_convert - copies rsl.error.0000 for each of the convert_emiss
runs to PREPLOGS.